### PR TITLE
Fix for authentication exception in RuleBuilder.

### DIFF
--- a/src/main/java/org/sonar/report/pdf/builder/RuleBuilder.java
+++ b/src/main/java/org/sonar/report/pdf/builder/RuleBuilder.java
@@ -93,7 +93,10 @@ public class RuleBuilder {
       // ruleKey = URLEncoder.encode(ruleKey, "UTF8");
       LOG.debug("Accessing Sonar: getting violated resurces by one given rule (" + ruleKey + ")");
 
-      SonarClient client = SonarClient.create(credentials.getUrl());
+      SonarClient client = SonarClient.builder().url(credentials.getUrl())
+                                                .login(credentials.getUsername())
+                                                .password(credentials.getPassword())
+                                                .build();
       IssueClient issueClient = client.issueClient();
 
       IssueQuery issueQuery = IssueQuery.create();


### PR DESCRIPTION
This is a fix for the authentication error that occurred when sonar had the option 'force user authentication' enabled. 

Turns out that in RuleBuilder:loadViolatedResources(), the credentials were available, but were not being passed to the SonarClient.

The original exception:
ERROR: Error during Sonar runner execution
org.sonar.runner.impl.RunnerException: Unable to execute Sonar
        at org.sonar.runner.impl.BatchLauncher$1.delegateExecution(BatchLauncher.java:91)
        at org.sonar.runner.impl.BatchLauncher$1.run(BatchLauncher.java:75)
        at java.security.AccessController.doPrivileged(Native Method)
        at org.sonar.runner.impl.BatchLauncher.doExecute(BatchLauncher.java:69)
        at org.sonar.runner.impl.BatchLauncher.execute(BatchLauncher.java:50)
        at org.sonar.runner.api.EmbeddedRunner.doExecute(EmbeddedRunner.java:102)
        at org.sonar.runner.api.Runner.execute(Runner.java:100)
        at org.sonar.runner.Main.executeTask(Main.java:70)
        at org.sonar.runner.Main.execute(Main.java:59)
        at org.sonar.runner.Main.main(Main.java:53)
Caused by: org.sonar.wsclient.base.HttpException: Error 401 on http://localhost:9000/api/issues/search?pageSize=20&componentRoots=anExp&rules=squid:S1860
        at org.sonar.wsclient.internal.HttpRequestFactory.execute(HttpRequestFactory.java:153)
        at org.sonar.wsclient.internal.HttpRequestFactory.get(HttpRequestFactory.java:129)
        at org.sonar.wsclient.issue.internal.DefaultIssueClient.find(DefaultIssueClient.java:49)
        at org.sonar.report.pdf.builder.RuleBuilder.loadViolatedResources(RuleBuilder.java:105)
        at org.sonar.report.pdf.builder.ProjectBuilder.initMostViolatedRulesFromNode(ProjectBuilder.java:248)
        at org.sonar.report.pdf.builder.ProjectBuilder.initMostViolatedRules(ProjectBuilder.java:175)
        at org.sonar.report.pdf.builder.ProjectBuilder.initializeProject(ProjectBuilder.java:98)
        at org.sonar.report.pdf.PDFReporter.getProject(PDFReporter.java:132)
        at org.sonar.report.pdf.PDFReporter.getReport(PDFReporter.java:82)
        at org.sonar.report.pdf.batch.PDFGenerator.execute(PDFGenerator.java:107)
        at org.sonar.report.pdf.batch.PDFPostJob.executeOn(PDFPostJob.java:80)
        at org.sonar.batch.phases.PostJobsExecutor.execute(PostJobsExecutor.java:72)
        at org.sonar.batch.phases.PostJobsExecutor.execute(PostJobsExecutor.java:61)
        at org.sonar.batch.phases.PhaseExecutor.execute(PhaseExecutor.java:132)
        at org.sonar.batch.scan.ModuleScanContainer.doAfterStart(ModuleScanContainer.java:194)
        at org.sonar.api.platform.ComponentContainer.startComponents(ComponentContainer.java:93)
        at org.sonar.api.platform.ComponentContainer.execute(ComponentContainer.java:78)
        at org.sonar.batch.scan.ProjectScanContainer.scan(ProjectScanContainer.java:233)
        at org.sonar.batch.scan.ProjectScanContainer.scanRecursively(ProjectScanContainer.java:228)
        at org.sonar.batch.scan.ProjectScanContainer.doAfterStart(ProjectScanContainer.java:221)
        at org.sonar.api.platform.ComponentContainer.startComponents(ComponentContainer.java:93)
        at org.sonar.api.platform.ComponentContainer.execute(ComponentContainer.java:78)
        at org.sonar.batch.scan.ScanTask.scan(ScanTask.java:64)
        at org.sonar.batch.scan.ScanTask.execute(ScanTask.java:51)
        at org.sonar.batch.bootstrap.TaskContainer.doAfterStart(TaskContainer.java:125)
        at org.sonar.api.platform.ComponentContainer.startComponents(ComponentContainer.java:93)
        at org.sonar.api.platform.ComponentContainer.execute(ComponentContainer.java:78)
        at org.sonar.batch.bootstrap.BootstrapContainer.executeTask(BootstrapContainer.java:173)
        at org.sonar.batch.bootstrapper.Batch.executeTask(Batch.java:95)
        at org.sonar.batch.bootstrapper.Batch.execute(Batch.java:67)
        at org.sonar.runner.batch.IsolatedLauncher.execute(IsolatedLauncher.java:48)
        at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:57)
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.lang.reflect.Method.invoke(Method.java:606)
        at org.sonar.runner.impl.BatchLauncher$1.delegateExecution(BatchLauncher.java:87)
        ... 9 more